### PR TITLE
Switched to CUDA 12.4 build only

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,13 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [cuda11, cuda12]
+        build: [cuda12]
         include:
-          - build: cuda11
-            image: nvidia/cuda:11.7.1-devel-ubuntu22.04
-            modeldir: /llamasharp_ci/models_benchmark
           - build: cuda12
-            image: nvidia/cuda:12.1.1-devel-ubuntu22.04
+            image: nvidia/cuda:12.4.0-devel-ubuntu22.04
             modeldir: /llamasharp_ci/models_benchmark
 
     container:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -347,7 +347,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        cuda: ['12.2.0', '11.7.1']
+        cuda: ['12.4.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone


### PR DESCRIPTION
This switches to only building CUDA 12.4, it should fix the multimodal build. I did a test run here which built everything, but failed to find the llava binaries, so I think once it's merged into this multimodal branch it should work.